### PR TITLE
Add CI and pre-commit

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -18,7 +18,7 @@
             "userGid": "automatic"
         }
 	},
-	"postStartCommand": "poetry install",
+	"postStartCommand": "poetry install && poetry run pre-commit install",
     "remoteUser": "vscode",
     "customizations": {
         "vscode": {

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -23,7 +23,7 @@
             "userGid": "automatic"
         }
 	},
-	"postStartCommand": "poetry install --with gpu",
+	"postStartCommand": "poetry install --with gpu && poetry run pre-commit install",
 	"remoteUser": "vscode",
 	"customizations": {
 		"vscode": {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "poetry"
+      - name: Install dependencies
+        run: |
+          poetry install
+      - name: Check code format
+        run: poetry run ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/fastai/nbdev
+  rev: 2.2.10
+  hooks:
+  - id: nbdev_clean
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.2
+  hooks:
+  - id: ruff-format
+    types_or: [ python, pyi, jupyter ]

--- a/README.md
+++ b/README.md
@@ -29,3 +29,21 @@ Docker・[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-nat
 ## 貢献方法
 
 [リポジトリへの貢献ガイド](https://github.com/tpu-dsg/.github/blob/main/CONTRIBUTING.md)を参照してください。
+
+コードの品質を保つために`pre-commit`を使用しています。`*ipynb`,`*.py`ファイルをコミットする前に以下の手順で`pre-commit`をセットアップしてください。（Dockerでは自動でセットアップされるので`poetry shell`を実行するだけです！）
+
+1. 依存関係のインストール
+
+    リポジトリの`pyproject.toml`を使用している場合はインストール済みなので不要です。
+    ```bash
+    pip install pre-commit nbdev ruff
+    ```
+
+2. Git フックのインストール
+
+    Poetry環境は事前に`poetry shell`を実行してください。
+    ```bash
+    pre-commit install
+    ```
+
+これでコミット時にJupyter Notebookの不要なメタデータの削除とコードフォーマットが行われるようになりました。コミット時に`pre-commit`が**Failed**となった場合は新たな差分ができているので、ステージして再コミットしてください。


### PR DESCRIPTION
## 関連するIssue

## 変更内容
- `pre-commit`による`nbdev_clean`の導入
  Jupyter Notebookは実行しただけでメタデータが変わる悪魔みたいな仕様により、Gitによる共同開発が困難という問題がある。この変更によってコミット前に不要なメタデータを削除するようになり、問題を回避する事ができる。
- Ruffフォーマッターの導入
  `pre-commit`で自動フォーマットを実行し、GitHub actionでフォーマットルールに従っているかチェックする

参考:
https://nbdev.fast.ai/tutorials/git_friendly_jupyter.html

https://docs.astral.sh/ruff/
### 懸念
変更によってコントリビュートへの障壁が高まる。リポジトリがぐちゃぐちゃになる懸念とどう折り合いをつけるか
## 備考
CIでフォーマットを自動整形しようか検討中