### PR TITLE
Fix MathJax instant loading behavior

### DIFF
--- a/docs/assets/js/mathjax.js
+++ b/docs/assets/js/mathjax.js
@@ -11,6 +11,9 @@ window.MathJax = {
     }
   };
   
-  document$.subscribe(() => {
-    MathJax.typesetPromise()
-  })
+  document$.subscribe(() => {    
+      MathJax.startup.output.clearCache()
+      MathJax.typesetClear()
+      MathJax.texReset()
+      MathJax.typesetPromise()
+    })


### PR DESCRIPTION
## 関連するIssue

## 変更内容

- Instant loading時にMathJaxが正常にロードされない問題を修正

## 備考

https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#arithmatex-docsjavascriptsmathjaxjs